### PR TITLE
remove limit in csv exporter

### DIFF
--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -11,7 +11,7 @@ module CsvExporter
       csv << CSV.generate_line(header)
       columns.map!{|c| c.to_s.split('.').map(&:to_sym)}
       resources.uncached do
-        resources.reorder(nil).limit(nil).find_each do |obj|
+        resources.reorder(nil).find_each do |obj|
           csv << CSV.generate_line(columns.map{|c| c.inject(obj, :try)})
         end
       end


### PR DESCRIPTION
The limit is overriden anyways by `find_each`, but in Rails 5 the limit
causes a failure in the will_paginate gem.